### PR TITLE
Generic number formatter

### DIFF
--- a/src/formatters/formatToGenericPhone.ts
+++ b/src/formatters/formatToGenericPhone.ts
@@ -1,0 +1,54 @@
+import mapToNumeric from "../helpers/mapToNumeric";
+
+/**
+ * Formats a phone value into brazilian common phone formats.
+ * @example ```js
+ * formatToGenericPhone('23456789')
+ * //=> '2345-6789'
+ *
+ * formatToGenericPhone('923456789')
+ * //=> '92345-6789'
+ *
+ * formatToGenericPhone('21923456789')
+ * //=> '(21) 92345-6789'
+ *
+ * formatToGenericPhone('021923456789')
+ * //=> '021 92345-6789'
+ *
+ * formatToGenericPhone('5521923456789')
+ * //=> '+55 21 92345-6789'
+ * ```
+ * @param value
+ * @param countryCodeLength
+ */
+const formatToGenericPhone = (
+  value: string,
+  /*
+    Brazil country code: +55
+  */
+  countryCodeLength: number = 2
+): string => {
+  const phone = mapToNumeric(value);
+  if (phone.length === 8) {
+    return phone.replace(/(^\d{4})(\d{4}$)/gi, "$1-$2");
+  }
+  if (phone.length === 9) {
+    return phone.replace(/(^\d{5})(\d{4}$)/gi, "$1-$2");
+  }
+  if (phone.length === 10) {
+    return phone.replace(/(^\d{2})(\d{4})(\d{4}$)/gi, "($1) $2-$3");
+  }
+  if (phone.length === 11) {
+    return phone.replace(/(^\d{2})(\d{4,5})(\d{4}$)/gi, "($1) $2-$3");
+  }
+  if (phone.length === 12) {
+    return phone.replace(/(^\d{3})(\d{5})(\d{4}$)/gi, "$1 $2-$3");
+  }
+  const re = new RegExp(
+    `([0-9]{${countryCodeLength}})([0-9][0-9])([0-9]{5})([0-9]{4})`,
+    "gi"
+  );
+  return phone.replace(re, "+$1 $2 $3-$4");
+};
+
+export default formatToGenericPhone;

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -10,3 +10,4 @@ export { default as formatToList } from './formatToList';
 export { default as formatToNumber } from './formatToNumber';
 export { default as formatToPhone } from './formatToPhone';
 export { default as formatToRG } from './formatToRG';
+export { default as formatToGenericPhone } from './formatToGenericPhone';

--- a/test/formatters.test.ts
+++ b/test/formatters.test.ts
@@ -12,6 +12,7 @@ import {
   formatToNumber,
   formatToPhone,
   formatToRG,
+  formatToGenericPhone
 } from '../src/brazilian-values';
 
 test('formatToBRL', (context) => {
@@ -98,4 +99,12 @@ test('formatToRG', (context) => {
   context.is(formatToRG('00.000.000-B', 'SP'), '00.000.000-B');
   context.is(formatToRG('00000000x', 'RJ'), '00.000.000-X');
   context.is(formatToRG('MG-14.808.688', 'MG'), 'MG-14.808.688');
+});
+
+test('formatToGenericPhone', (context) => {
+  context.is(formatToGenericPhone('23456789'), '2345-6789')
+  context.is(formatToGenericPhone('923456789'), '92345-6789')
+  context.is(formatToGenericPhone('21923456789'), '(21) 92345-6789')
+  context.is(formatToGenericPhone('021923456789'), '021 92345-6789')
+  context.is(formatToGenericPhone('5521923456789'), '+55 21 92345-6789')
 });


### PR DESCRIPTION
Formata números telefônicos e de celulares, usando a regra do 9. Considerando DDD e código do país (pode ser alterado através do segundo parâmetro)