### PR TITLE
Fix phone number format according to Anatel

### DIFF
--- a/src/formatters/formatToPhone.ts
+++ b/src/formatters/formatToPhone.ts
@@ -10,7 +10,7 @@ import mapToNumeric from '../helpers/mapToNumeric';
  * //=> '(11) 9716-26'
  *
  * formatToPhone('11971626799')
- * //=> '(11) 9 7162-6799'
+ * //=> '(11) 97162-6799'
  * ```
  * @param value
  */
@@ -21,7 +21,7 @@ const formatToPhone = (
     .replace(/(\d{1,2})/, '($1')
     .replace(/(\(\d{2})(\d{1,4})/, '$1) $2')
     .replace(/( \d{4})(\d{1,4})/, '$1-$2')
-    .replace(/( \d{1})(\d{3})(?:-)(\d{1})(\d{4})/, '$1 $2$3-$4')
+    .replace(/( \d{4})(?:-)(\d{1})(\d{4})/, '$1$2-$3')
 );
 
 export default formatToPhone;

--- a/src/validators/isPhone.ts
+++ b/src/validators/isPhone.ts
@@ -4,17 +4,17 @@ import isDDD from './isDDD';
  * Pattern for common brazilian telephone number formats, optionally with DDI,
  * DDD and the ninth digit.
  */
-const PHONE_PATTERN = /^(\+55)? ?\(?(\d{2})?\)? ?9? ?\d{4}[-| ]?\d{4}$/;
+const PHONE_PATTERN = /^(\+55)? ?\(?(\d{2})?\)? ?9?\d{4}[-| ]?\d{4}$/;
 
 /**
  * Check if value is a valid brazilian phone number. It can check a wide
  * variety of formats optionally with DDI, DDD and the ninth digit.
  * 
  * @example ```js
- * isPhone('+55 (11) 9 8273-1182')
+ * isPhone('+55 (11) 98273-1182')
  * //=> true
  * 
- * isPhone('11 9 8273 1182')
+ * isPhone('11 98273 1182')
  * //=> true
  * 
  * isPhone('1139723768')
@@ -23,7 +23,7 @@ const PHONE_PATTERN = /^(\+55)? ?\(?(\d{2})?\)? ?9? ?\d{4}[-| ]?\d{4}$/;
  * isPhone('(23) 3972-3768')
  * //=> false
  * 
- * isPhone('(13) 6 5093-2093')
+ * isPhone('(13) 65093-2093')
  * //=> false
  * 
  * isPhone('(81) 555 178')

--- a/test/formatters.test.ts
+++ b/test/formatters.test.ts
@@ -119,7 +119,7 @@ test('formatToPhone', (context) => {
   context.is(formatToPhone('11'), '(11');
   context.is(formatToPhone('11971626'), '(11) 9716-26');
   context.is(formatToPhone('1197162679'), '(11) 9716-2679');
-  context.is(formatToPhone('11971626799'), '(11) 9 7162-6799');
+  context.is(formatToPhone('11971626799'), '(11) 97162-6799');
 });
 
 test('formatToRG', (context) => {

--- a/test/validators.test.ts
+++ b/test/validators.test.ts
@@ -80,8 +80,8 @@ test('isDDD', (context) => {
 });
 
 test('isPhone', (context) => {
-  context.true(isPhone('+55 (11) 9 8273-1182'));
-  context.true(isPhone('11 9 8273 1182'));
+  context.true(isPhone('+55 (11) 98273-1182'));
+  context.true(isPhone('11 98273 1182'));
   context.true(isPhone('1139723768'));
   context.false(isPhone('(23) 3972-3768'));
   context.false(isPhone('(13) 6 5093-2093'));


### PR DESCRIPTION
According to the Brazilian government's page, https://www.gov.br/anatel/pt-br/regulado/numeracao/plano-de-numeracao-brasileiro, there is no space after the first digit when the phone has a length of 9 digits.

> Nove dígitos [**abcde-mcdu**], para o caso do Serviço Móvel Pessoal (telefonia móvel celular).

This also follows Google's `libphonenumber` default _National_ formatting for brazilian numbers, [as demoed here](https://catamphetamine.github.io/libphonenumber-js/?parseCountry=BR&parseValue=11912345678).

This is also documented in several other documents issued by the government, like:

- https://sistemas.anatel.gov.br/anexar-api/publico/portal-publicar/documentos?numeroPublicacao=344387, page 3
- https://www.gov.br/anatel/pt-br/regulado/numeracao/tabela-servico-movel-celular
- https://www.gov.br/anatel/pt-br/regulado/numeracao/nono-digito